### PR TITLE
Upgrade dokka from 0.9.18 to 0.10.1

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -10,7 +10,7 @@ plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.2
 
 plugin.org.danilopianini.publish-on-central=0.2.1
 
-plugin.org.jetbrains.dokka=0.9.18
+plugin.org.jetbrains.dokka=0.10.1
 
 plugin.org.jlleitschuh.gradle.ktlint=8.0.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.