### PR TITLE
Upgrade kotlin from 1.3.72 to 1.4.0-rc

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -16,6 +16,6 @@ plugin.org.jlleitschuh.gradle.ktlint=9.3.0
 
 version.kotest=4.1.3
 
-version.kotlin=1.3.72
+version.kotlin=1.4.0-rc
 
 version.kotlinx.coroutines=1.3.8


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.