### PR TITLE
Upgrade kotest from 4.2.0.RC1 to 4.2.0.RC2

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -14,7 +14,7 @@ plugin.org.jetbrains.dokka=0.10.1
 
 plugin.org.jlleitschuh.gradle.ktlint=9.3.0
 
-version.kotest=4.2.0.RC1
+version.kotest=4.2.0.RC2
 
 version.kotlin=1.3.72
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.