### PR TITLE
Upgrade coroutines from 1.3.8 to 1.3.9

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -18,4 +18,4 @@ version.kotest=4.2.0.RC2
 
 version.kotlin=1.3.72
 
-version.kotlinx.coroutines=1.3.8
+version.kotlinx.coroutines=1.3.9


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.