### PR TITLE
Upgrade coroutines from 1.3.8 to 1.4.1

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -19,4 +19,4 @@ version.kotest=4.1.2
 
 version.kotlin=1.3.72
 
-version.kotlinx.coroutines=1.3.8
+version.kotlinx.coroutines=1.4.1


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.