### PR TITLE
Upgrade kotlin from 1.3.72 to 1.4.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -17,6 +17,6 @@ plugin.org.jlleitschuh.gradle.ktlint=9.4.1
 
 version.kotest=4.1.3
 
-version.kotlin=1.3.72
+version.kotlin=1.4.0
 
 version.kotlinx.coroutines=1.3.8


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.