### PR TITLE
Upgrade kotlin from 1.4.21 to 1.4.30

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -17,6 +17,6 @@ plugin.org.jlleitschuh.gradle.ktlint=9.4.1
 
 version.kotest=4.4.0
 
-version.kotlin=1.4.21
+version.kotlin=1.4.30
 
 version.kotlinx.coroutines=1.4.2


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.