### PR TITLE
Upgrade kotlin from 1.4.30 to 1.4.31

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -17,6 +17,6 @@ plugin.org.jlleitschuh.gradle.ktlint=10.0.0
 
 version.kotest=4.4.1
 
-version.kotlin=1.4.30
+version.kotlin=1.4.31
 
 version.kotlinx.coroutines=1.4.2


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.