### PR TITLE
Upgrade kotlin from 1.4.32 to 1.5.10

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -17,6 +17,6 @@ plugin.org.jlleitschuh.gradle.ktlint=10.1.0
 
 version.kotest=4.5.0
 
-version.kotlin=1.4.32
+version.kotlin=1.5.10
 
 version.kotlinx.coroutines=1.4.3


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.