### PR TITLE
Upgrade kotest from 4.5.0 to 4.6.1

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -15,7 +15,7 @@ plugin.org.jetbrains.dokka=1.5.0
 
 plugin.org.jlleitschuh.gradle.ktlint=10.1.0
 
-version.kotest=4.5.0
+version.kotest=4.6.1
 
 version.kotlin=1.4.32
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.