### PR TITLE
feat!: consider both annotated and lightweight tags by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ gitSemVer {
     // Many project are versioned with tags named "vX.Y.Z", de-facto building valid SemVer versions but for the leading "v".
     // If it is the case for some project, setting this property to "v" would make these tags readable as SemVer tags.
     versionPrefix.set("")
+    // This reproduces the behavior of the plugin at version 0.x.y: ignores non-annotated (lightweight) tags.
+    excludeLightweightTags()
 }
 ```
 

--- a/src/main/kotlin/org/danilopianini/gradle/gitsemver/GitSemVerExtension.kt
+++ b/src/main/kotlin/org/danilopianini/gradle/gitsemver/GitSemVerExtension.kt
@@ -43,7 +43,7 @@ open class GitSemVerExtension @JvmOverloads constructor(
     val buildMetadataSeparator: Property<String> = project.propertyWithDefault("+"),
     val distanceCounterRadix: Property<Int> = project.propertyWithDefault(DEFAULT_RADIX),
     val versionPrefix: Property<String> = project.propertyWithDefault(""),
-    val includeLightweightTags: Property<Boolean> = project.propertyWithDefault(false),
+    val includeLightweightTags: Property<Boolean> = project.propertyWithDefault(true),
 ) {
 
     private fun computeMinVersion(logger: Logger): SemanticVersion {
@@ -157,8 +157,8 @@ open class GitSemVerExtension @JvmOverloads constructor(
     /**
      * If called, the system will also consider non-annotated tags.
      */
-    fun includeLightweightTags() {
-        includeLightweightTags.set(true)
+    fun excludeLightweightTags() {
+        includeLightweightTags.set(false)
     }
 
     companion object {

--- a/src/test/kotlin/org/danilopianini/gradle/gitsemver/test/Tests.kt
+++ b/src/test/kotlin/org/danilopianini/gradle/gitsemver/test/Tests.kt
@@ -4,6 +4,7 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import org.gradle.internal.impldep.org.junit.rules.TemporaryFolder
 import org.gradle.testkit.runner.GradleRunner
 import java.util.concurrent.TimeUnit
@@ -79,16 +80,24 @@ internal class Tests : StringSpec(
             result shouldContain expectedVersion
         }
         "support for lightweight tags (#323)" {
+            val workingDirectory = configuredPlugin()
+            with(workingDirectory) {
+                initGit()
+                runCommand("git", "tag", "1.2.3")
+            }
+            workingDirectory.runGradle() shouldContain "1.2.3"
+        }
+        "exclusion of lightweight tags (#323)" {
             val workingDirectory = configuredPlugin(
                 """
-                includeLightweightTags() 
+                excludeLightweightTags() 
                 """.trimIndent()
             )
             with(workingDirectory) {
                 initGit()
                 runCommand("git", "tag", "1.2.3")
             }
-            workingDirectory.runGradle() shouldContain "1.2.3"
+            workingDirectory.runGradle() shouldNotContain "1.2.3"
         }
     }
 ) {


### PR DESCRIPTION
To reproduce the previous behaviour, use:

```kotlin
gitSemVer {
    excludeLightweightTags()
}
```