### PR TITLE
perf!: make the plugin compatible with Gradle's configuration cache

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,7 +85,7 @@ tasks {
     withType<KotlinCompile> {
         kotlinOptions {
             allWarningsAsErrors = true
-            freeCompilerArgs += listOf("-opt-in=kotlin.RequiresOptIn", "-Xinline-classes")
+            freeCompilerArgs += listOf("-opt-in=kotlin.RequiresOptIn", "-Xinline-classes", "-Xcontext-receivers")
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,7 +85,7 @@ tasks {
     withType<KotlinCompile> {
         kotlinOptions {
             allWarningsAsErrors = true
-            freeCompilerArgs += listOf("-opt-in=kotlin.RequiresOptIn", "-Xinline-classes", "-Xcontext-receivers")
+            freeCompilerArgs += listOf("-opt-in=kotlin.RequiresOptIn", "-Xinline-classes")
         }
     }
 }

--- a/src/main/kotlin/org/danilopianini/gradle/gitsemver/GitSemVer.kt
+++ b/src/main/kotlin/org/danilopianini/gradle/gitsemver/GitSemVer.kt
@@ -2,18 +2,29 @@ package org.danilopianini.gradle.gitsemver
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ProviderFactory
+import javax.inject.Inject
 
 /**
  * A Plugin for comuting the project version based on the status of the local git repository.
  */
-class GitSemVer : Plugin<Project> {
+class GitSemVer @Inject constructor(
+    private val providerFactory: ProviderFactory,
+    private val objectFactory: ObjectFactory,
+) : Plugin<Project> {
 
     override fun apply(project: Project) {
         with(project) {
             /*
              * Recursively scan project directory. If git repo is found, rely on GitSemVerExtension to inspect it.
              */
-            val extension = project.createExtension<GitSemVerExtension>(GitSemVerExtension.EXTENSION_NAME, project)
+            val extension = project.createExtension<GitSemVerExtension>(
+                GitSemVerExtension.EXTENSION_NAME,
+                project,
+                providerFactory,
+                objectFactory,
+            )
             project.afterEvaluate {
                 with(extension) {
                     properties[extension.forceVersionPropertyName.get()]?.let {

--- a/src/main/kotlin/org/danilopianini/gradle/gitsemver/source/GitCommandValueSource.kt
+++ b/src/main/kotlin/org/danilopianini/gradle/gitsemver/source/GitCommandValueSource.kt
@@ -1,0 +1,53 @@
+package org.danilopianini.gradle.gitsemver.source
+
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.process.ExecOperations
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.nio.charset.Charset
+import javax.inject.Inject
+
+/**
+ * Value source for reading results of external git commands.
+ */
+abstract class GitCommandValueSource : ValueSource<String, Parameters> {
+
+    /**
+     * Execution operations instance to execute external process.
+     */
+    @get:Inject
+    abstract val execOperations: ExecOperations
+
+    override fun obtain(): String {
+        val output = ByteArrayOutputStream()
+
+        execOperations.exec {
+            it.apply {
+                commandLine = parameters.commands.get()
+                workingDir = parameters.directory.get()
+                standardOutput = output
+                isIgnoreExitValue = true
+            }
+        }
+        return String(output.toByteArray(), Charset.defaultCharset())
+    }
+}
+
+/**
+ * Parameters for passing down git command list.
+ */
+interface Parameters : ValueSourceParameters {
+
+    /**
+     * List of commands to execute in an external process.
+     */
+    val commands: ListProperty<String>
+
+    /**
+     * Working directory to execute external process in.
+     */
+    val directory: Property<File>
+}


### PR DESCRIPTION
TL;DR 
This PR addresses #676 and makes [git-sensitive-semantic-versioning-gradle-plugin](https://github.com/DanySK/git-sensitive-semantic-versioning-gradle-plugin) compatible with configuration cache.

Gradle [configuration cache](https://docs.gradle.org/current/userguide/configuration_cache.html) allows to significantly reduce configuration time and improve build performance by caching results of configuration phase.
There is a [list of requirements](https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:requirements) to adhere for configuration cache compatibility.
This PR adresses two separate issues with previous implementation:
- Usage of `Runtime.exec()` for handling external processes 
- Isolation of `Project` instance during configuration

>I had an idea of enabling context receivers to pass down implicit dependencies introduced by lifting Project but it looks like context receivers are not compatible with configuration cache due to a [bug](https://github.com/gradle/gradle/issues/27725) so instead I opted for moving runCommand suite functions into extension for easier access to dependencies needed.

Changes were extensively tested locally.

Additional thing to consider: PR changes the contract of `assignGitSemanticVersion()` function from internal mutation of the project.version to returning the computed value without mutation. 
Since `assignGitSemanticVersion()` is a part of the public API this introduces a **BREAKING CHANGE** for consumers who rely on the side effect nature of original `assignGitSemanticVersion()` to update project.version.