### PR TITLE
feat: relax `runCommand` function visibility to `protected`

### DIFF
--- a/src/main/kotlin/org/danilopianini/gradle/gitsemver/GitSemVerExtension.kt
+++ b/src/main/kotlin/org/danilopianini/gradle/gitsemver/GitSemVerExtension.kt
@@ -192,7 +192,7 @@ open class GitSemVerExtension @JvmOverloads constructor(
         includeLightweightTags.set(false)
     }
 
-    private fun runCommand(vararg cmd: String) = processCommand(*cmd)
+    protected fun runCommand(vararg cmd: String) = processCommand(*cmd)
 
     private fun processCommand(vararg cmd: String) = createValueSourceProvider(*cmd)
         .get()


### PR DESCRIPTION
This solves #679 by making runCommand protected to avoid duplicating logic in subclasses.