### PR TITLE
feat: add computeReleaseVersion property to support release versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ gitSemVer {
     maxVersionLength.set(Int.MAX_VALUE) // Useful to limit the maximum version length, e.g. Gradle Plugins have a limit on 20
     developmentCounterLength.set(2) // How many digits after `dev`
     enforceSemanticVersioning.set(true) // Whether the plugin should stop if the resulting version is not a valid SemVer, or just warn
+    computeReleaseVersion.set(false) // You can decide whether the generated version should be for releases or pre-releases (default behaviour)
     // The separator for the pre-release block.
     // Changing it to something else than "+" may result in non-SemVer compatible versions
     preReleaseSeparator.set("-")
@@ -91,6 +92,40 @@ gitSemVer {
 ```
 
 `./gradlew -PmyCustomPropertyVersion=1.2.3 <task list>` will result in the project version being set to `1.2.3`.
+
+### Compute the version for release
+
+By default, the extension calculates the version for pre-releases, but you can
+force the calculation of the version for releases by setting the `computeReleaseVersion`
+property to `true`. However, manually forcing the version (as described in
+[Manually force the version](#manually-force-the-version)) still takes priority
+over this property.
+
+Consider the following configuration example:
+
+```kotlin
+// task that the release fulfils
+project.tasks.register("release")
+
+gitSemVer {
+    computeReleaseVersion.set(
+        project.tasks.named("release").map {
+            project.gradle.taskGraph.hasTask(it)
+        }
+    )
+}
+```
+
+With this configuration, the extension will calculate the pre-release version
+until you force the release by executing the ‘release’ task. As soon as you
+decide to release the project, the extension will calculate the release version
+for you.
+
+In combination with conventional commits, which will be described below, this
+almost completely frees you from manually determining the project version. You
+only have to decide what the ‘release’ task should do during execution. Probably
+`git commit ...` and `git tag ...`, using `project.version` for this, but that's
+up to you.
 
 ### Using conventional commits?
 

--- a/src/main/kotlin/org/danilopianini/gradle/gitsemver/GitSemVerExtension.kt
+++ b/src/main/kotlin/org/danilopianini/gradle/gitsemver/GitSemVerExtension.kt
@@ -25,7 +25,8 @@ import kotlin.time.toJavaDuration
  * - [developmentCounterLength], how many digits to use for the counter
  * - [enforceSemanticVersioning], whether the system should fail or just warn
  *      in case a non-SemVer compatible version gets produced
- * - [computeReleaseVersion], determines whether the version is to be calculated for the release or pre-release (default behavior)
+ * - [computeReleaseVersion], determines whether the version is to be calculated for the release or pre-release
+ *      (default behavior)
  * - [preReleaseSeparator], how to separate the pre-relase information.
  *      Changing this value may generate non-SemVer-compatible versions.
  * - [buildMetadataSeparator], how to separate the pre-relase information.
@@ -142,9 +143,9 @@ constructor(
                 val buildSeparator = buildMetadataSeparator.get()
 
                 if (computeReleaseVersion) {
-                    return "$base".take(maxVersionLength.get())
+                    "$base".take(maxVersionLength.get())
                 } else {
-                    return "$base$separator$identifier$buildSeparator$hash".take(maxVersionLength.get())
+                    "$base$separator$identifier$buildSeparator$hash".take(maxVersionLength.get())
                 }
             }
 
@@ -188,9 +189,9 @@ constructor(
                         val buildSeparator = buildMetadataSeparator.get()
 
                         if (computeReleaseVersion) {
-                            return "$currentVersion".take(maxVersionLength.get())
+                            "$currentVersion".take(maxVersionLength.get())
                         } else {
-                            return "$currentVersion$separator$devString$distanceString$buildSeparator$hash"
+                            "$currentVersion$separator$devString$distanceString$buildSeparator$hash"
                                 .take(maxVersionLength.get())
                         }
                     }

--- a/src/test/kotlin/org/danilopianini/gradle/gitsemver/test/Tests.kt
+++ b/src/test/kotlin/org/danilopianini/gradle/gitsemver/test/Tests.kt
@@ -172,6 +172,15 @@ internal class Tests :
                     .directory(root)
                     .redirectError(ProcessBuilder.Redirect.INHERIT)
                     .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+                    .apply {
+                        // git command isolation from the operating system environment
+                        environment().let { env ->
+                            env.clear()
+                            env["PATH"] = System.getenv("PATH")
+                            env["HOME"] = root.resolve(".git/.home.d/").absolutePath
+                            env["GIT_CONFIG_NOSYSTEM"] = "true"
+                        }
+                    }
                     .start()
             process.waitFor(wait, TimeUnit.SECONDS)
             require(process.exitValue() == 0) {

--- a/src/test/kotlin/org/danilopianini/gradle/gitsemver/test/Tests.kt
+++ b/src/test/kotlin/org/danilopianini/gradle/gitsemver/test/Tests.kt
@@ -86,7 +86,7 @@ internal class Tests :
                                 project.gradle.taskGraph.hasTask(it)
                             }
                         )
-                        """.trimIndent()
+                        """.trimIndent(),
                     ) {
                         initGit()
                     }


### PR DESCRIPTION
### Description

This pull request introduces a new `computeReleaseVersion` property for managing release-specific version calculations. Key changes include:

- Added `computeReleaseVersion` option to `GitSemVerExtension`.
- Adjusted logic to compute release versions seamlessly.
- Updated related tests to ensure proper coverage for this feature.
- Enhanced documentation to reflect the new property and behavior.

Additionally, the test environment has been improved to isolate Git command execution from system variables, ensuring consistent test results across environments.

### Checklist

- [x] Tests have been added or updated.
- [x] Documentation has been updated, if necessary